### PR TITLE
Absolutify README link to prevent 404 in NPM package page

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ module.exports = {
 };
 ```
 
-For specifics on how the config for each rule should be formatted, see [their specific rule files](/src/rules/).
+For specifics on how the config for each rule should be formatted, see [their specific rule files](https://github.com/birjolaxew/svglint/tree/master/src/rules).
 
 If you are using the JS API, this configuration object is passed as the second parameter.
 


### PR DESCRIPTION
The link in [NPM package README](https://www.npmjs.com/package/svglint) is pointing to `https://www.npmjs.com/src/rules/`.