### PR TITLE
Fail throwing Error from custom rule

### DIFF
--- a/src/lib/linting.js
+++ b/src/lib/linting.js
@@ -171,14 +171,14 @@ class Linting extends EventEmitter {
         for (let k in this.results) {
             const result = this.results[k];
             if (result instanceof Array) {
-                if (result.some(res => res.hasErrors)) {
+                if (result.some(res => res.hasErrors) || result.some(res => res.hasExceptions)) {
                     return STATES.error;
                 }
                 if (result.some(res => res.hasWarns)) {
                     state = STATES.warn;
                 }
             } else {
-                if (result.hasErrors) {
+                if (result.hasErrors || result.hasExceptions) {
                     return STATES.error;
                 }
                 if (result.hasWarns) {

--- a/src/lib/linting.js
+++ b/src/lib/linting.js
@@ -171,7 +171,7 @@ class Linting extends EventEmitter {
         for (let k in this.results) {
             const result = this.results[k];
             if (result instanceof Array) {
-                if (result.some(res => res.hasErrors) || result.some(res => res.hasExceptions)) {
+                if (result.some(res => res.hasErrors || res.hasExceptions)) {
                     return STATES.error;
                 }
                 if (result.some(res => res.hasWarns)) {

--- a/test/custom.spec.js
+++ b/test/custom.spec.js
@@ -112,11 +112,11 @@ describe("Rule: custom", function(){
         ]);
     });
     it("should fail with an exception inside function", function(){
-      return testFails([
-          () => {
-            throw new Error("Foo");
-          }
-      ]);
+        return testFails([
+            () => {
+                throw new Error("Foo");
+            }
+        ]);
     });
     it("should fail with an erroring function", function(){
         return testFails([

--- a/test/custom.spec.js
+++ b/test/custom.spec.js
@@ -111,6 +111,13 @@ describe("Rule: custom", function(){
             })
         ]);
     });
+    it("should fail with an exception inside function", function(){
+      return testFails([
+          () => {
+            throw new Error("Foo");
+          }
+      ]);
+    });
     it("should fail with an erroring function", function(){
         return testFails([
             (reporter, $, ast) => {


### PR DESCRIPTION
Closes #20 

If you throw an `Error` from a custom rule is not reported, failing silently. I have used the `error` state in the absence of an `exception` state, but I'm not that familiar with the implementation as to define a new state because I'm not sure of the implications.