### PR TITLE
Add .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,9 @@
+# Ignore all files in root
+/*
+# Except the ones we want to publish
+!bin/
+!src/
+!package.json
+!example.png
+!LICENSE
+!README.md


### PR DESCRIPTION
Add an `.npmignore` file to ignore certain files/folders when publishing. I uesd a whitelist style, first ignoring everything and then listing only the things that should be published.

Most notably this will remove dot-files and folders as well as the tests.

I kept `example.png` because it's used in the README. It can be removed later if that's preferred.