### PR TITLE
Show error tracebacks reading config files in CLI

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -63,7 +63,7 @@ process.on("exit", () => {
         const configFile = await getConfigurationFile(cli.flags.config);
         configObj = require(configFile);
     } catch (e) {
-        logger.error(`Failed to parse config:\n${e.stack}`);
+        logger.error(`Failed to parse config: ${e.stack}`);
         process.exit(1);
     }
 

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -63,7 +63,7 @@ process.on("exit", () => {
         const configFile = await getConfigurationFile(cli.flags.config);
         configObj = require(configFile);
     } catch (e) {
-        logger.error(`Failed to parse config: ${e.message}`);
+        logger.error(`Failed to parse config:\n${e.stack}`);
         process.exit(1);
     }
 


### PR DESCRIPTION
This pull only changes the output displayed in CLI for errors catched reading configuration files, for easier debugging.

### Before

```
> svglint icons/*.svg --ci

--------------------------- Log ---------------------------
(x) Failed to parse config: Unexpected token ':'

------------------------- Summary -------------------------
- No files linted
```

### After

```
> svglint icons/*.svg --ci

--------------------------------------- Log ---------------------------------------
(x) Failed to parse config:
/.../simple-icons/scripts/utils.js:45
      (_, ref) => {quot: '"', amp: '&', lt: '<', gt: '>'}[ref]
                                 ^

SyntaxError: Unexpected token ':'
    at wrapSafe (internal/modules/cjs/loader.js:988:16)
    at Module._compile (internal/modules/cjs/loader.js:1036:27)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1101:10)
    at Module.load (internal/modules/cjs/loader.js:937:32)
    at Function.Module._load (internal/modules/cjs/loader.js:778:12)
    at Module.require (internal/modules/cjs/loader.js:961:19)
    at require (internal/modules/cjs/helpers.js:92:18)
    at Object.<anonymous> (/.../simple-icons/.svglintrc.js:4:33)
    at Module._compile (internal/modules/cjs/loader.js:1072:14)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1101:10)

------------------------------------- Summary -------------------------------------
- No files linted
```
