### PR TITLE
Fix require path error in examples

### DIFF
--- a/src/rules/examples/async.js
+++ b/src/rules/examples/async.js
@@ -1,4 +1,4 @@
-const logger = require("../lib/logger")("rule:async");
+const logger = require("../../lib/logger")("rule:async");
 
 /**
  * @typedef AsyncConfig

--- a/src/rules/examples/elms.js
+++ b/src/rules/examples/elms.js
@@ -1,4 +1,4 @@
-const logger = require("../lib/logger")("rule:elms");
+const logger = require("../../lib/logger")("rule:elms");
 
 /**
  * @typedef ElmsConfig

--- a/src/rules/examples/identity.js
+++ b/src/rules/examples/identity.js
@@ -1,4 +1,4 @@
-const logger = require("../lib/logger")("rule:identity");
+const logger = require("../../lib/logger")("rule:identity");
 
 /**
  * @typedef IdentityConfig

--- a/src/rules/examples/throws.js
+++ b/src/rules/examples/throws.js
@@ -1,4 +1,4 @@
-const logger = require("../lib/logger")("rule:throws");
+const logger = require("../../lib/logger")("rule:throws");
 
 /**
  * @typedef ThrowsConfig


### PR DESCRIPTION
I'm getting the next error trying to run the examples:

```
bin/cli.js --config src/rules/examples/elms.js

(x) Failed to parse config: Error: Cannot find module '../lib/logger'
     at Function.Module._resolveFilename (internal/modules/cjs/loader.js:603:15)
     at Function.Module._load (internal/modules/cjs/loader.js:529:25)
     at Module.require (internal/modules/cjs/loader.js:657:17)
     at require (internal/modules/cjs/helpers.js:22:18)
     at Object.<anonymous> (/home/mondeja/files/code/svglint/src/rules/examples/elms.js:1:78)
     at Module._compile (internal/modules/cjs/loader.js:721:30)
     at Object.Module._extensions..js (internal/modules/cjs/loader.js:732:10)
     at Module.load (internal/modules/cjs/loader.js:620:32)
     at tryModuleLoad (internal/modules/cjs/loader.js:560:12)
     at Function.Module._load (internal/modules/cjs/loader.js:552:3)
```

Could be in conflict with #41

