### PR TITLE
Add attr special rule to enforce attributes ordering

### DIFF
--- a/src/rules/attr.js
+++ b/src/rules/attr.js
@@ -67,32 +67,36 @@ function executeOnElm($elm, config, reporter, ast) {
 
     if (config["rule::order"]) {
         const attributes = Object.keys(attrs);
-        let order, prevIndex = -1;
-        if (config["rule::order"] === true) {
-            // alphabetical ordering
-            order = attributes.slice();
-            order.sort();
-        } else {
-            order = config["rule::order"];
+        if (attributes.length > 0) {
+            let order;
+            if (config["rule::order"] === true) {
+                // alphabetical ordering
+                order = attributes.slice();
+                order.sort();
+            } else {
+                order = config["rule::order"];
+            }
+
+            let prevIndex = order.indexOf(attributes[0]);
+            for (let i = 1; i < attributes.length; i++) {
+                const index = order.indexOf(attributes[i]);
+                if (index === -1) {
+                    // this attribute doesn't need ordering, ignore it
+                    return;
+                }
+
+                if (prevIndex !== -1 && index < prevIndex) {
+                    reporter.error(
+                        `Wrong ordering of attributes, found "${
+                            attributes.join(", ")}", expected "${order.join(", ")}"`,
+                        $elm,
+                        ast
+                    );
+                    break;
+                }
+                prevIndex = index;
+            }
         }
-
-        attributes.forEach(attr => {
-            const index = order.indexOf(attr);
-            if (index === -1) {
-                // this attribute doesn't need ordering, ignore it
-                return;
-            }
-
-            if (prevIndex !== -1 && index < prevIndex) {
-                reporter.error(
-                    `Wrong ordering of attributes, found "${
-                        attributes.join(", ")}", expected "${order.join(", ")}"`,
-                    $elm,
-                    ast
-                );
-            }
-            prevIndex = index;
-        });
     }
 
     // check that all configs are met

--- a/src/rules/attr.js
+++ b/src/rules/attr.js
@@ -86,7 +86,7 @@ function executeOnElm($elm, config, reporter, ast) {
             if (prevIndex !== -1 && index < prevIndex) {
                 reporter.error(
                     `Wrong ordering of attributes, found "${
-                        attributes.join(", ")}", expected "${order.join(', ')}"`,
+                        attributes.join(", ")}", expected "${order.join(", ")}"`,
                     $elm,
                     ast
                 );

--- a/src/rules/attr.js
+++ b/src/rules/attr.js
@@ -15,6 +15,7 @@ const logger = require("../lib/logger")("rule:attr");
  * The following special configs are allowed:
  * - `{ "rule::selector": {String} }` Default "*". The matching elements must fulfill the other configs.
  * - `{ "rule::whitelist": {Boolean} }` Default `false`. If true, no other attributes can exist than those specified by the other configs.
+ * - `{ "rule::order": {Array<String>} }` Default null. If not null, attributes must be defined in the provided order.
  */
 
 /**
@@ -30,7 +31,7 @@ const logger = require("../lib/logger")("rule:attr");
  *   - If whitelist is true, error if there are attributes left
  */
 
-const SPECIAL_ATTRIBS = ["rule::selector", "rule::whitelist"];
+const SPECIAL_ATTRIBS = ["rule::selector", "rule::whitelist", "rule::order"];
 
 /**
  * Executes on a single element.
@@ -141,6 +142,29 @@ function executeOnElm($elm, config, reporter, ast) {
                 ast
             );
         }
+    }
+
+    if (config["rule::order"]) {
+        let remaining = Object.keys(attrs);
+        const order = config["rule::order"];
+        if (order.length > remaining.length) {
+            reporter.warn(
+                `Ordering defines ${order.length} attributes, more than ${remaining.length} found`,
+                $elm,
+                ast
+            );
+        } else {
+            remaining = remaining.slice(0, config["rule::order"].length);
+        }
+        remaining.forEach((attr, i) => {
+            if (attr !== order[i]) {
+                reporter.error(
+                    `Wrong ordering of '${attr}' attribute, expected '${order[i]}' at position ${i + 1}`,
+                    $elm,
+                    ast
+                );
+            }
+        });
     }
 }
 

--- a/test/attr.spec.js
+++ b/test/attr.spec.js
@@ -38,6 +38,7 @@ const testSVG = `<svg role="img" viewBox="0 0 24 24">
     </g>
     <g></g>
     <circle></circle>
+    <rect height="100" width="300" style="fill:black;" />
 </svg>`;
 
 function inspect(obj) {
@@ -195,6 +196,24 @@ describe("Rule: attr", function(){
         return testFails({
             "rule::selector": "svg",
             "rule::whitelist": true,
+        });
+    });
+    it("should succeed enforcing right attributes ordering", function() {
+        return testSucceeds({
+            "rule::selector": "rect",
+            "rule::order": ["height", "width", "style"],
+        });
+    });
+    it("should fail enforcing wrong attributes ordering", function() {
+        return testFails({
+            "rule::selector": "rect",
+            "rule::order": ["width", "style", "height"],
+        });
+    });
+    it("should succeed enforcing ordering of first attributes", function() {
+        return testSucceeds({
+            "rule::selector": "rect",
+            "rule::order": ["height", "width"],
         });
     });
 });

--- a/test/attr.spec.js
+++ b/test/attr.spec.js
@@ -216,4 +216,31 @@ describe("Rule: attr", function(){
             "rule::order": ["height", "width"],
         });
     });
+    it("should succeed enforcing soft ordering of some attributes", function() {
+        return testSucceeds({
+            "rule::selector": "rect",
+            "rule::order": ["height", "style"],
+        });
+    });
+    it("should succeed enforcing alphabetical ordering with true", function() {
+        return testSucceeds({
+            "rule::selector": "svg",
+            "rule::order": true,
+        });
+    });
+    it("should fail enforcing alphabetical ordering", function() {
+        return testFails({
+            "rule::selector": "rect",
+            "rule::order": true,
+        });
+    });
+    it("should succeed enforcing hard ordering with whitelist", function() {
+        return testSucceeds({
+            "role": true,
+            "viewBox": true,
+            "rule::selector": "svg",
+            "rule::whitelist": true,
+            "rule::order": true,
+        });
+    });
 });


### PR DESCRIPTION
Closes #46

~~This implementation checks ordering of first attributes. If the element found has more attributes than those passed in `rule::order` and the order of these attributes is correct, then the linter will pass without throwing errors.~~