### PR TITLE
Allow to disable color in output

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -10,7 +10,7 @@ import SVGLint from "../src/svglint.js";
 // @ts-ignore
 import config from "../src/cli/config.js";
 import meow from "meow";
-import chalk from "chalk";
+import { chalk } from "../src/cli/util.js";
 import glob from "glob";
 
 const GUI = new gui();

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,18 @@
         "chalk": "^2.0.0",
         "esutils": "^2.0.2",
         "js-tokens": "^4.0.0"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        }
       }
     },
     "@commitlint/execute-rule": {
@@ -534,14 +546,9 @@
       }
     },
     "chalk": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-      "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-      "requires": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      }
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.0.0.tgz",
+      "integrity": "sha512-/duVOqst+luxCQRKEo4bNxinsOQtMP80ZYm7mMqzuh5PociNL0PvmHFvREJ9ueYL2TxlHjBcmLCdmocx9Vg+IQ=="
     },
     "chardet": {
       "version": "0.7.0",
@@ -797,6 +804,19 @@
             "lodash.map": "^4.5.1",
             "longest": "^2.0.1",
             "word-wrap": "^1.0.3"
+          },
+          "dependencies": {
+            "chalk": {
+              "version": "2.4.2",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+              "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+              "dev": true,
+              "requires": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+              }
+            }
           }
         },
         "glob": {
@@ -1005,6 +1025,19 @@
         "lodash.map": "^4.5.1",
         "longest": "^2.0.1",
         "word-wrap": "^1.0.3"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        }
       }
     },
     "debug": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "ansi-regex": "^5.0.1",
-    "chalk": "^2.4.1",
+    "chalk": "^5.0.0",
     "cheerio": "^1.0.0-rc.6",
     "fast-xml-parser": "^3.12.13",
     "glob": "^7.1.2",
@@ -58,15 +58,26 @@
     }
   },
   "release": {
-    "branches": ["master"],
+    "branches": [
+      "master"
+    ],
     "plugins": [
-      ["@semantic-release/commit-analyzer", {
-        "preset": "angular",
-        "releaseRules": [
-          { "type": "docs", "release": "patch" },
-          { "type": "chore", "release": "patch" }
-        ]
-      }],
+      [
+        "@semantic-release/commit-analyzer",
+        {
+          "preset": "angular",
+          "releaseRules": [
+            {
+              "type": "docs",
+              "release": "patch"
+            },
+            {
+              "type": "chore",
+              "release": "patch"
+            }
+          ]
+        }
+      ],
       "@semantic-release/release-notes-generator",
       "@semantic-release/npm",
       "@semantic-release/github"

--- a/src/cli/components/linting.js
+++ b/src/cli/components/linting.js
@@ -1,5 +1,4 @@
-import chalk from "chalk";
-import { chunkString, MSG_META, COLUMNS } from "../util.js";
+import { chalk, chunkString, MSG_META, COLUMNS } from "../util.js";
 import stripAnsi from "strip-ansi";
 
 import Spinner from "./spinner.js";

--- a/src/cli/components/log.js
+++ b/src/cli/components/log.js
@@ -1,5 +1,5 @@
 import nodeUtil from "util";
-import { MSG_META } from "../util.js";
+import { MSG_META, supportsColor } from "../util.js";
 
 /** @typedef {import("../../lib/logger.js").CliConsole} CliHistory */
 
@@ -12,7 +12,7 @@ function stringifyArgs(args=[]) {
         v => (
             typeof v === "string"
                 ? v
-                : nodeUtil.inspect(v, { colors: true, depth: 3 })
+                : nodeUtil.inspect(v, { colors: supportsColor, depth: 3 })
         ).replace(/^Error: /, "")
     ).join(" ");
 }
@@ -30,7 +30,7 @@ export default class Log {
                 ? `[${meta.symbol}|${msg.prefix}]`
                 : `(${meta.symbol})`;
             const message = stringifyArgs(msg.args);
-            return meta.color(prefix) + " "
+            return (supportsColor ? meta.color(prefix) : prefix) + " "
                 + message;
         }).join("\n");
     }

--- a/src/cli/components/separator.js
+++ b/src/cli/components/separator.js
@@ -1,4 +1,4 @@
-import chalk from "chalk";
+import { chalk } from "../util.js";
 const columns = process.stdout.columns || 80;
 
 /**

--- a/src/cli/components/summary.js
+++ b/src/cli/components/summary.js
@@ -1,5 +1,4 @@
-import chalk from "chalk";
-import { MSG_META } from "../util.js";
+import { chalk, MSG_META } from "../util.js";
 
 /** @typedef {import("../../lib/linting.js")} Linting */
 

--- a/src/cli/util.js
+++ b/src/cli/util.js
@@ -8,12 +8,7 @@ const supportsColor = chalkSupportsColor &&
     !("NO_COLOR" in process.env) &&
     !("SVGLINT_NO_COLOR" in process.env);
 
-let chalk;
-if (supportsColor) {
-    chalk = new Chalk();
-} else {
-    chalk = new Chalk({level: 0});
-}
+let chalk = supportsColor ? new Chalk() : new Chalk({level: 0});
 
 const COLUMNS = process.stdout.columns || 80;
 const MSG_META = Object.freeze({

--- a/src/cli/util.js
+++ b/src/cli/util.js
@@ -1,8 +1,19 @@
 /**
  * @fileoverview Utilities for the CLI.
  */
-import chalk from "chalk";
+import { Chalk, supportsColor as chalkSupportsColor } from "chalk";
 import ansiRegex from "ansi-regex";
+
+const supportsColor = chalkSupportsColor &&
+    !("NO_COLOR" in process.env) &&
+    !("SVGLINT_NO_COLOR" in process.env);
+
+let chalk;
+if (supportsColor) {
+    chalk = new Chalk();
+} else {
+    chalk = new Chalk({level: 0});
+}
 
 const COLUMNS = process.stdout.columns || 80;
 const MSG_META = Object.freeze({
@@ -40,7 +51,9 @@ const MSG_META = Object.freeze({
 });
 
 export {
+    chalk,
     chunkString,
+    supportsColor,
     MSG_META,
     COLUMNS,
 };

--- a/src/lib/logger.js
+++ b/src/lib/logger.js
@@ -3,9 +3,9 @@
  * If called using the JS API, this will be `console` with prefixes.
  * If called using the CLI, this will be our own custom logger.
  */
-import chalk from "chalk";
 import { inspect } from "util";
 import { EventEmitter } from "events";
+import { chalk, supportsColor } from "../cli/util.js";
 
 const CONSOLE_COLORS = Object.freeze({
     debug: chalk.dim.gray,
@@ -25,12 +25,11 @@ const METHODS = ["debug", "log", "warn", "error"];
 let isCLI = false;
 let level = LEVELS.log;
 
+
 // create a prefixing & colorizing wrapper around console for use in non-CLIs
 const wrappedConsole = Object.create(console);
 METHODS.forEach(method => {
-    const color = CONSOLE_COLORS[method]
-        ? CONSOLE_COLORS[method]
-        : v => v;
+    const color = CONSOLE_COLORS[method];
     wrappedConsole[method] = (prefix, args) => {
         // eslint-disable-next-line no-console
         console[method].apply(console, [color("["+prefix+"]"), ...args]);
@@ -79,5 +78,6 @@ Logger.cliConsole = cliConsole;
 Logger.setCLI = value => { isCLI = value; };
 Logger.setLevel = value => { level = value; };
 Logger.LEVELS = LEVELS;
-Logger.colorize = value => inspect(value, true, 2, true);
+Logger.colorize = supportsColor ?
+    value => inspect(value, true, 2, true) : value => value;
 export default Logger;

--- a/src/lib/logger.js
+++ b/src/lib/logger.js
@@ -25,11 +25,12 @@ const METHODS = ["debug", "log", "warn", "error"];
 let isCLI = false;
 let level = LEVELS.log;
 
-
 // create a prefixing & colorizing wrapper around console for use in non-CLIs
 const wrappedConsole = Object.create(console);
 METHODS.forEach(method => {
-    const color = CONSOLE_COLORS[method];
+    const color = CONSOLE_COLORS[method]
+        ? CONSOLE_COLORS[method]
+        : v => v;
     wrappedConsole[method] = (prefix, args) => {
         // eslint-disable-next-line no-console
         console[method].apply(console, [color("["+prefix+"]"), ...args]);

--- a/src/lib/reporter.js
+++ b/src/lib/reporter.js
@@ -2,7 +2,7 @@
  * @fileoverview The object that rules use to report errors, warnings and messages.
  */
 import { EventEmitter } from "events";
-import chalk from "chalk";
+import { chalk } from "../cli/util.js";
 import Logger from "./logger.js";
 
 /** @typedef {import("./parse.js").AST} AST */

--- a/test/attr.spec.js
+++ b/test/attr.spec.js
@@ -1,7 +1,7 @@
-import chalk from "chalk";
 import util from "util";
 
 import SVGLint from "../src/svglint.js";
+import { chalk } from "../src/cli/util.js";
 
 process.on("unhandledRejection", error => {
     console.error(error); // eslint-disable-line no-console

--- a/test/custom.spec.js
+++ b/test/custom.spec.js
@@ -1,7 +1,7 @@
-import chalk from "chalk";
 import util from "util";
 
 import SVGLint from "../src/svglint.js";
+import { chalk } from "../src/cli/util.js";
 
 process.on("unhandledRejection", error => {
     console.error(error); // eslint-disable-line no-console

--- a/test/elm.spec.js
+++ b/test/elm.spec.js
@@ -1,7 +1,7 @@
-import chalk from "chalk";
 import util from "util";
 
 import SVGLint from "../src/svglint.js";
+import { chalk } from "../src/cli/util.js";
 
 process.on("unhandledRejection", error => {
     console.error(error); // eslint-disable-line no-console

--- a/test/valid.spec.js
+++ b/test/valid.spec.js
@@ -1,7 +1,7 @@
-import chalk from "chalk";
 import util from "util";
 
 import SVGLint from "../src/svglint.js";
+import { chalk } from "../src/cli/util.js";
 
 process.on("unhandledRejection", error => {
     console.error(error); // eslint-disable-line no-console


### PR DESCRIPTION
By setting the environment variables:

- `NO_COLOR`
- `SVGLINT_NO_COLOR`

And all the checks done by [supports-color](https://github.com/chalk/supports-color), like [terminal is not a TTY](https://github.com/chalk/supports-color/blob/2a5846724b19ac94eb96b2842cf4b7751af0d8e4/index.js#L83), setting the [environment variable `TERM` to `dumb` value](https://github.com/chalk/supports-color/blob/2a5846724b19ac94eb96b2842cf4b7751af0d8e4/index.js#L89), passing [`--no-color` command line option](https://github.com/chalk/supports-color/blob/2a5846724b19ac94eb96b2842cf4b7751af0d8e4/index.js#L17)... These are all included in latest version of chalk (v5) by default. This version is only compatible with Node>=12.20, so it is in line with SVGLint support.

I've not included a check for `color` option in config file, let me know if it is really desired, I think that it would add too much regardless complexity.

Closes #50