### PR TITLE
Add tests for CLI color outputs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1390,46 +1390,6 @@
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
     },
-    "execa": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-6.0.0.tgz",
-      "integrity": "sha512-m4wU9j4Z9nXXoqT8RSfl28JSwmMNLFF69OON8H/lL3NeU0tNpGz313bcOfYoBBHokB0dC2tMl3VUcKgHELhL2Q==",
-      "dev": true,
-      "requires": {
-        "cross-spawn": "^7.0.3",
-        "get-stream": "^6.0.1",
-        "human-signals": "^3.0.1",
-        "is-stream": "^3.0.0",
-        "merge-stream": "^2.0.0",
-        "npm-run-path": "^5.0.1",
-        "onetime": "^6.0.0",
-        "signal-exit": "^3.0.5",
-        "strip-final-newline": "^3.0.0"
-      },
-      "dependencies": {
-        "mimic-fn": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
-          "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
-          "dev": true
-        },
-        "onetime": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
-          "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
-          "dev": true,
-          "requires": {
-            "mimic-fn": "^4.0.0"
-          }
-        },
-        "signal-exit": {
-          "version": "3.0.6",
-          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.6.tgz",
-          "integrity": "sha512-sDl4qMFpijcGw22U5w63KmD3cZJfBuFlVNbVMKje2keoKML7X2UzWbc4XrmEbDwg0NXJc3yv4/ox7b+JWb57kQ==",
-          "dev": true
-        }
-      }
-    },
     "expand-tilde": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
@@ -1654,12 +1614,6 @@
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "dev": true
     },
-    "get-stream": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
-      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
-      "dev": true
-    },
     "glob": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
@@ -1822,12 +1776,6 @@
         "inherits": "^2.0.1",
         "readable-stream": "^2.0.2"
       }
-    },
-    "human-signals": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-3.0.1.tgz",
-      "integrity": "sha512-rQLskxnM/5OCldHo+wNXbpVgDn5A17CUoKX+7Sokwaknlq7CdSnphy0W39GU8dw59XiCXmFXDg4fRuckQRKewQ==",
-      "dev": true
     },
     "iconv-lite": {
       "version": "0.4.24",
@@ -2026,12 +1974,6 @@
       "requires": {
         "has": "^1.0.1"
       }
-    },
-    "is-stream": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
-      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
-      "dev": true
     },
     "is-string": {
       "version": "1.0.4",
@@ -2332,12 +2274,6 @@
       "integrity": "sha512-jz+Cfrg9GWOZbQAnDQ4hlVnQky+341Yk5ru8bZSe6sIDTCIg8n9i/u7hSQGSVOF3C7lH6mGtqjkiT9G4wFLL0w==",
       "dev": true
     },
-    "merge-stream": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
-      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
-      "dev": true
-    },
     "merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -2563,23 +2499,6 @@
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "dev": true
-    },
-    "npm-run-path": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.0.1.tgz",
-      "integrity": "sha512-ybBJQUSyFwEEhqO2lXmyKOl9ucHtyZBWVM0h0FiMfT/+WKxCUZFa95qAR2X3w/w6oigN3B0b2UNHZbD+kdfD5w==",
-      "dev": true,
-      "requires": {
-        "path-key": "^4.0.0"
-      },
-      "dependencies": {
-        "path-key": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
-          "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
-          "dev": true
-        }
-      }
     },
     "nth-check": {
       "version": "2.0.1",
@@ -3113,12 +3032,6 @@
           "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA=="
         }
       }
-    },
-    "strip-final-newline": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
-      "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
-      "dev": true
     },
     "strip-indent": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "commitizen": "^4.2.4",
     "cz-conventional-changelog": "^3.3.0",
     "eslint": "^8.3.0",
-    "execa": "^6.0.0",
     "expect": "^1.20.2",
     "mocha": "^9.1.3",
     "rollup": "^2.61.1"

--- a/test/cli.spec.js
+++ b/test/cli.spec.js
@@ -14,7 +14,7 @@ async function execCliWith(args, env) {
     }
     argv.push([...args]);
 
-    return await new Promise(function(resolve){
+    return await new Promise(resolve => {
         const child = spawn(
             "node",
             argv,
@@ -26,7 +26,7 @@ async function execCliWith(args, env) {
 
         const stdoutChunks = [], stderrChunks = [];
         let stdout, stderr;
-        child.on("exit", (code) => {
+        child.on("exit", code => {
             resolve({
                 stdout,
                 stderr,
@@ -35,14 +35,14 @@ async function execCliWith(args, env) {
             });
         });
 
-        child.stdio[1].on("data", (data) => {
+        child.stdio[1].on("data", data => {
             stdoutChunks.push(data.toString());
         });
         child.stdio[1].on("end", () => {
             stdout = stdoutChunks.join("");
         });
 
-        child.stdio[2].on("data", (data) => {
+        child.stdio[2].on("data", data => {
             stderrChunks.push(data.toString());
         });
         child.stdio[2].on("end", () => {


### PR DESCRIPTION
Following from #53

The main problem is that when the process is spawned from Nodejs, the colors are not shown because the terminal is not a tty. This is one of the first checks done by [supports-color](https://github.com/chalk/supports-color/). So we can pass always `--colors` to enable color by default wihout environment and test our own checks for color disabling. The rest of the checks done by supports-color should be OK.

Also, I've removed `execa` development dependency as it is only used here, ofuscating things I think.